### PR TITLE
Fail if description or comment check fails

### DIFF
--- a/src/pr_checks.py
+++ b/src/pr_checks.py
@@ -108,7 +108,7 @@ class PRChecks:
                 self.create_comment_conditionally(check.get("message_if_matching"))
             else:
                 self.create_comment_conditionally(check.get("message_if_not_matching"))
-                print(f"Title check failed - PR title {title} does not match regex {check['regex']}")
+                print(f"Title check failed - PR title '{title}' does not match regex '{check['regex']}' ")
                 title_success = False
 
             return title_success
@@ -121,7 +121,8 @@ class PRChecks:
                 self.create_comment_conditionally(check.get("message_if_matching"))
             else:
                 self.create_comment_conditionally(check.get("message_if_not_matching"))
-                print(f"Description check failed - PR description {description} does not match regex {check['regex']}")
+                print(f"Description check failed - "
+                      f"PR description '{description}' does not match regex '{check['regex']}'")
                 description_success = False
         return description_success
 

--- a/src/pr_checks.py
+++ b/src/pr_checks.py
@@ -83,7 +83,7 @@ class PRChecks:
             print(f"Event {self.event_name} not supported, this action only supports pull_request events")
             return False
         try:
-            self._run_checks()
+            success = self._run_checks()
             self.pr.update()
         except github.GithubException as e:
             print(f"Github API error running checks: {e}. Check your configuration file and repository permissions.")
@@ -91,8 +91,8 @@ class PRChecks:
             print(f"Error running checks: {e}")
             raise e
         else:
-            print("PR checks completed successfully")
-            return True
+            print("PR checks completed")
+            return success
 
     def _run_checks(self):
         print(f"Running PR checks for PR #{self.pr.number} ({self.pr.title})")
@@ -102,19 +102,28 @@ class PRChecks:
 
     def run_title_checks(self):
         title = self.pr.title
+        title_success = True
         for check in self.config["pr_checks"].get("title", []):
             if re.match(check["regex"], title):
                 self.create_comment_conditionally(check.get("message_if_matching"))
             else:
                 self.create_comment_conditionally(check.get("message_if_not_matching"))
+                print(f"Title check failed - PR title {title} does not match regex {check['regex']}")
+                title_success = False
+
+            return title_success
 
     def run_description_checks(self):
         description = self.pr.body or ""  # body can be None, using empty string for regex matching
+        description_success = True
         for check in self.config["pr_checks"].get("description", []):
             if re.match(check["regex"], description):
                 self.create_comment_conditionally(check.get("message_if_matching"))
             else:
                 self.create_comment_conditionally(check.get("message_if_not_matching"))
+                print(f"Description check failed - PR description {description} does not match regex {check['regex']}")
+                description_success = False
+        return description_success
 
     def run_files_changed_checks(self):
         files_changed = self.pr.get_files()


### PR DESCRIPTION
Checks will fail if one of the regexes does not match. An appropriate message will also be printed out to the logs for easier debugging. 